### PR TITLE
Add support for f-strings

### DIFF
--- a/bombast/transform.py
+++ b/bombast/transform.py
@@ -1,4 +1,4 @@
-from ast import Num, Str, List, Tuple, Set, Dict # NameConstant
+from ast import Num, Str, List, Tuple, Set, Dict, Constant, JoinedStr, FormattedValue # NameConstant
 from ast import Name, Load, Store, Del, Starred
 from ast import Expr, UnaryOp, UAdd, USub, Not, BinOp
 from ast import Add, Sub, Mult, Div, FloorDiv, Mod, Pow

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -56,3 +56,9 @@ args[::-1]
 (y+1 for y in args)
 {y: y+1 for y in args}
 [x+y for x in args for y in args]
+
+# f-strings
+f'Empty f-string'
+f'Here is x: {x}!'
+f'Three plus two is {3 + 2}'
+f'Some fancily formatted number: ${126783.6457:,.2f}'

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -60,5 +60,9 @@ args[::-1]
 # f-strings
 f'Empty f-string'
 f'Here is x: {x}!'
+f'Here is repr(x): {x!r}!'
+f'Here is x plus two: {x + 2}!'
 f'Three plus two is {3 + 2}'
 f'Some fancily formatted number: ${126783.6457:,.2f}'
+f'Here is x and z: {x}, {z}'
+f'Here is {x=} and {z=}'


### PR DESCRIPTION
Bombast currently fails to obfuscate code containing f-strings, which have the form `f'My value is {value}!'`. This is because the `NodeTransformer` will walk down the tree of the `JoinedStr` (the AST type corresponding to f-strings), and Bombast will rewrite the `Constant` values inside the `f-string` to obfuscate the `Str`s, generating `BinOp` nodes instead. However, The only valid children of `JoinedStr` are `Constant` and `FormattedValue` values, so this adds a `visit_JoinedStr` to the transformer to handle this case properly.