### PR TITLE
Remove stale version-specific cases.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.x"]
+        python-version: ["3.9", "3.10", "3.x"]
     name: Python ${{ matrix.python-version }}
     steps:
       - name: Checkout source

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bombast [![Build Status](https://github.com/brianhou/bombast/workflows/tests/badge.svg)](https://github.com/brianhou/bombast/actions/workflows/tests.yml) [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/release/python-380/)
+# bombast [![Build Status](https://github.com/brianhou/bombast/workflows/tests/badge.svg)](https://github.com/brianhou/bombast/actions/workflows/tests.yml) [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/release/python-390/)
 
 An obfuscator for Python 3 source code that manipulates the AST.
 

--- a/bombast/__init__.py
+++ b/bombast/__init__.py
@@ -56,7 +56,7 @@ class Bombast(ast.NodeTransformer):
 
     def visit_Expr(self, node):
         if isinstance(node.value, Str): # docstring
-            return Expr(Str(s=random.randident(20, 30), kind=None))
+            return Expr(Str(s=random.randident(20, 30)))
         return Expr(self.visit(node.value))
 
     def visit_Num(self, node):

--- a/bombast/__init__.py
+++ b/bombast/__init__.py
@@ -56,7 +56,7 @@ class Bombast(ast.NodeTransformer):
 
     def visit_Expr(self, node):
         if isinstance(node.value, Str): # docstring
-            return Expr(Str(s=random.randident(20, 30), **DEFAULT_CONSTANT_KWARGS))
+            return Expr(Str(s=random.randident(20, 30), kind=None))
         return Expr(self.visit(node.value))
 
     def visit_Num(self, node):

--- a/bombast/__init__.py
+++ b/bombast/__init__.py
@@ -1,6 +1,5 @@
 import argparse
 import ast
-import astunparse
 import builtins
 import sys
 
@@ -166,7 +165,7 @@ def main():
     root.body.sort(key=lambda x: not isinstance(x, ast.Import)) # move imports
     ast.fix_missing_locations(root) # fix AST
 
-    print(astunparse.unparse(root), file=args.outfile)
+    print(ast.unparse(root), file=args.outfile)
     if args.show_translations:
         for original, obfuscated in preprocess.mapping.items():
             print(original, '=', obfuscated)

--- a/bombast/__init__.py
+++ b/bombast/__init__.py
@@ -90,20 +90,13 @@ class Bombast(ast.NodeTransformer):
         args = [self.visit(arg) for arg in node.args]
         kwonlyargs = [self.visit(arg) for arg in node.kwonlyargs]
         defaults, kw_defaults = node.defaults, node.kw_defaults
-        if VERSION[:2] < (3, 4):
-            vararg = self.rename(node.vararg)
-            kwarg = self.rename(node.kwarg)
-            as_kwargs = dict(args=args, vararg=vararg, varargannotation=node.varargannotation,
-                             kwonlyargs=kwonlyargs, kwarg=kwarg, kwargannotation=node.kwargannotation,
-                             defaults=defaults, kw_defaults=kw_defaults)
-        else:
-            posonlyargs = [self.visit(posonlyarg) for posonlyarg in node.posonlyargs] if VERSION[:2] >= (3, 8) else []
-            vararg = kwarg = None
-            if node.vararg is not None:
-                vararg = arg(arg=self.rename(node.vararg.arg), annotation=node.vararg.annotation)
-            if node.kwarg is not None:
-                kwarg = arg(arg=self.rename(node.kwarg.arg), annotation=node.kwarg.annotation)
-            as_kwargs = dict(posonlyargs=posonlyargs, args=args, vararg=vararg, kwonlyargs=kwonlyargs, kw_defaults=kw_defaults, kwarg=kwarg, defaults=defaults)
+        posonlyargs = [self.visit(posonlyarg) for posonlyarg in node.posonlyargs]
+        vararg = kwarg = None
+        if node.vararg is not None:
+            vararg = arg(arg=self.rename(node.vararg.arg), annotation=node.vararg.annotation)
+        if node.kwarg is not None:
+            kwarg = arg(arg=self.rename(node.kwarg.arg), annotation=node.kwarg.annotation)
+        as_kwargs = dict(posonlyargs=posonlyargs, args=args, vararg=vararg, kwonlyargs=kwonlyargs, kw_defaults=kw_defaults, kwarg=kwarg, defaults=defaults)
         for key in list(as_kwargs.keys()):
             if key not in arguments._fields:
                 del as_kwargs[key]
@@ -127,13 +120,7 @@ class Bombast(ast.NodeTransformer):
         bases = [self.visit(b) for b in node.bases]
         body = [self.visit(b) for b in node.body]
         decorator_list = [self.visit(d) for d in node.decorator_list]
-        if VERSION[:2] < (3, 5):
-            return ClassDef(name, bases,
-                            node.keywords, node.starargs, node.kwargs,
-                            body, decorator_list)
-        else:
-            return ClassDef(name, bases,
-                            node.keywords, body, decorator_list)
+        return ClassDef(name, bases, node.keywords, body, decorator_list)
 
 def configure(path):
     options = load_config(path)

--- a/bombast/transform.py
+++ b/bombast/transform.py
@@ -15,8 +15,6 @@ from ast import ClassDef
 
 from bombast.utils import *
 
-DEFAULT_CONSTANT_KWARGS = dict(kind=None) if sys.version_info[:2] >= (3, 8) else dict()
-
 class Transformation(object):
     def __init__(self, *fns):
         self.fns = fns
@@ -60,7 +58,7 @@ class StrBombast(PrimitiveBombast):
 
     def one_Ordinal(node): # 'a' -> chr(97)
         return Call(func=Name(id='chr', ctx=Load()),
-                    args=[Num(ord(node.s), **DEFAULT_CONSTANT_KWARGS)], keywords=[], starargs=None, kwargs=None)
+                    args=[Num(ord(node.s), kind=None)], keywords=[], starargs=None, kwargs=None)
     def one_Identity(node): # 'a' -> 'a'
         return node
     one = Transformation(one_Ordinal, one_Identity)
@@ -69,8 +67,8 @@ class StrBombast(PrimitiveBombast):
         s = node.s
         i = random.randrange(len(s))
         return BinOp(
-            left=Str(s=s[:i], **DEFAULT_CONSTANT_KWARGS),
-            right=Str(s=s[i:], **DEFAULT_CONSTANT_KWARGS),
+            left=Str(s=s[:i], kind=None),
+            right=Str(s=s[i:], kind=None),
             op=Add()
         )
     many = Transformation(many_Split)
@@ -89,7 +87,7 @@ class NumBombast(PrimitiveBombast):
     def zero_Multiplier(node): # 0 -> int(n * 0)
         return Call(
             func=Name(id='int', ctx=Load()),
-            args=[BinOp(left=Num(n=random.random(), **DEFAULT_CONSTANT_KWARGS), right=Num(n=0, **DEFAULT_CONSTANT_KWARGS), op=Mult())],
+            args=[BinOp(left=Num(n=random.random(), kind=None), right=Num(n=0, kind=None), op=Mult())],
             keywords=[], starargs=None, kwargs=None
         )
     def zero_Identity(node):
@@ -99,8 +97,8 @@ class NumBombast(PrimitiveBombast):
     def int_Split(node, range=100): # n -> (n-s) + (s)
         s = random.randint(-range, range)
         return BinOp(
-            left=Num(n=node.n-s, **DEFAULT_CONSTANT_KWARGS),
-            right=Num(n=s, **DEFAULT_CONSTANT_KWARGS),
+            left=Num(n=node.n-s, kind=None),
+            right=Num(n=s, kind=None),
             op=Add()
         )
     int = Transformation(int_Split)
@@ -108,8 +106,8 @@ class NumBombast(PrimitiveBombast):
     def float_Split(node): # n -> (n-s) + (s)
         s = random.random()
         return BinOp(
-            left=Num(n=node.n-s, **DEFAULT_CONSTANT_KWARGS),
-            right=Num(n=s, **DEFAULT_CONSTANT_KWARGS),
+            left=Num(n=node.n-s, kind=None),
+            right=Num(n=s, kind=None),
             op=Add()
         )
     float = Transformation(float_Split)
@@ -122,13 +120,13 @@ class ImportBombast(RenameBombast):
             targets=[Name(id=n.names[0].name, ctx=Store())],
             value=Call(func=Name(id='__import__', ctx=Load()),
                        args=[
-                           Str(s=n.names[0].name, **DEFAULT_CONSTANT_KWARGS),
+                           Str(s=n.names[0].name, kind=None),
                            Call(func=Name(id='globals', ctx=Load()),
                                 args=[], keywords=[], starargs=None, kwargs=None),
                            Call(func=Name(id='locals', ctx=Load()),
                                 args=[], keywords=[], starargs=None, kwargs=None),
                            List(elts=[], ctx=Load()),
-                           Num(n=0, **DEFAULT_CONSTANT_KWARGS)
+                           Num(n=0, kind=None)
                        ],
                        keywords=[], starargs=None, kwargs=None))
         )

--- a/bombast/transform.py
+++ b/bombast/transform.py
@@ -58,7 +58,7 @@ class StrBombast(PrimitiveBombast):
 
     def one_Ordinal(node): # 'a' -> chr(97)
         return Call(func=Name(id='chr', ctx=Load()),
-                    args=[Num(ord(node.s), kind=None)], keywords=[], starargs=None, kwargs=None)
+                    args=[Num(ord(node.s))], keywords=[], starargs=None, kwargs=None)
     def one_Identity(node): # 'a' -> 'a'
         return node
     one = Transformation(one_Ordinal, one_Identity)
@@ -67,8 +67,8 @@ class StrBombast(PrimitiveBombast):
         s = node.s
         i = random.randrange(len(s))
         return BinOp(
-            left=Str(s=s[:i], kind=None),
-            right=Str(s=s[i:], kind=None),
+            left=Str(s=s[:i]),
+            right=Str(s=s[i:]),
             op=Add()
         )
     many = Transformation(many_Split)
@@ -87,7 +87,7 @@ class NumBombast(PrimitiveBombast):
     def zero_Multiplier(node): # 0 -> int(n * 0)
         return Call(
             func=Name(id='int', ctx=Load()),
-            args=[BinOp(left=Num(n=random.random(), kind=None), right=Num(n=0, kind=None), op=Mult())],
+            args=[BinOp(left=Num(n=random.random()), right=Num(n=0), op=Mult())],
             keywords=[], starargs=None, kwargs=None
         )
     def zero_Identity(node):
@@ -97,8 +97,8 @@ class NumBombast(PrimitiveBombast):
     def int_Split(node, range=100): # n -> (n-s) + (s)
         s = random.randint(-range, range)
         return BinOp(
-            left=Num(n=node.n-s, kind=None),
-            right=Num(n=s, kind=None),
+            left=Num(n=node.n-s),
+            right=Num(n=s),
             op=Add()
         )
     int = Transformation(int_Split)
@@ -106,8 +106,8 @@ class NumBombast(PrimitiveBombast):
     def float_Split(node): # n -> (n-s) + (s)
         s = random.random()
         return BinOp(
-            left=Num(n=node.n-s, kind=None),
-            right=Num(n=s, kind=None),
+            left=Num(n=node.n-s),
+            right=Num(n=s),
             op=Add()
         )
     float = Transformation(float_Split)
@@ -120,13 +120,13 @@ class ImportBombast(RenameBombast):
             targets=[Name(id=n.names[0].name, ctx=Store())],
             value=Call(func=Name(id='__import__', ctx=Load()),
                        args=[
-                           Str(s=n.names[0].name, kind=None),
+                           Str(s=n.names[0].name),
                            Call(func=Name(id='globals', ctx=Load()),
                                 args=[], keywords=[], starargs=None, kwargs=None),
                            Call(func=Name(id='locals', ctx=Load()),
                                 args=[], keywords=[], starargs=None, kwargs=None),
                            List(elts=[], ctx=Load()),
-                           Num(n=0, kind=None)
+                           Num(n=0)
                        ],
                        keywords=[], starargs=None, kwargs=None))
         )

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ setup(
     url="https://github.com/brianhou/bombast",
     author="Brian Hou",
     packages=["bombast"],
-    install_requires=["astunparse>=1.6.3"],
-    python_requires="~=3.8",
+    python_requires="~=3.9",
     entry_points={
         "console_scripts": [
             "bombast=bombast.__init__:main",


### PR DESCRIPTION
Update minimum version to Python 3.9 to use `ast.unparse` rather than the external `astunparse` dependency. Remove version-specific cases that have become stale.
